### PR TITLE
Refactor to be able to call migration using pure function call.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,25 @@ pg-migrator
 
 The complete and easy to use command-line migration tool for [PostgreSQL](http://www.postgresql.org/).
 
+Also can be called directly via function call if you runing gulp or grunt.
+
+````javascript
+    var migrate = require('pg-migrator/migrate');
+
+    migrate({
+            connectionString: connectionString,
+            targetVersion: 5, // optional
+            path: './migrations' // migration scripts directory
+        })
+        .then(function () {
+            // migration completed
+        })
+        .catch(function (err) {
+            // migration failed
+        });
+
+````
+
 [![Build Status](https://travis-ci.org/Aphel-Cloud-Solutions/pg-migrator.png?branch=master)](https://travis-ci.org/Aphel-Cloud-Solutions/pg-migrator) [![Code Climate](https://codeclimate.com/github/Aphel-Cloud-Solutions/pg-migrator.png)](https://codeclimate.com/github/Aphel-Cloud-Solutions/pg-migrator)
 
 ## Features

--- a/bin/pg-migrator
+++ b/bin/pg-migrator
@@ -2,24 +2,7 @@
 
 "use strict";
 
-var fs = require("fs");
-var path = require("path");
-var colors = require("colors");
-var Pgb = require("pg-bluebird");
-
-GLOBAL._ = require("underscore");
-GLOBAL.promise = require("bluebird");
-
-var ValidationService = require("../lib/application/service/validation-service");
-var messages = require("../lib/infrastructure/messages");
-var persisterProvider = new Pgb();
-
-colors.setTheme({
-    verbose: 'cyan',
-    info: 'green',
-    warn: 'yellow',
-    error: 'red'
-});
+var migrate = require("../migrate");
 
 // First argument : connectionString (mandatory)
 // Second argument : target version (optional)
@@ -34,73 +17,28 @@ if (!isValid) {
 
 var connectionString = args[0];
 var targetVersion = 0;
+var migrationScriptsPath = '.';
 
 // if targetVersion stays 0 means that, target version does not provided by user
 // so it will be obtained from script files (the biggest target version number in all files)
 if (args.length > 1) {
-
     targetVersion = args[1];
 }
 
-var connection, currentPersister, currentVersion;
+if (args.length > 2) {
+    migrationScriptsPath = args[2];
+}
 
-// Connecting to PostgreSQL
-persisterProvider.connect(connectionString)
-    .then(function (persister) {
+var options = {
+    connectionString: connectionString,
+    targetVersion: targetVersion,
+    path: migrationScriptsPath
+}
 
-        connection = persister;
-        currentPersister = persister.client;
-
-        // Starting transaction
-        return currentPersister.query("BEGIN TRANSACTION");
-    })
+migrate(options)
     .then(function () {
-
-        return getMigrationService(currentPersister).migrate(".", targetVersion);
-    })
-    .then(function (curVer) {
-
-        currentVersion = curVer;
-
-        // Migration has been completed successfully, committing the transaction
-        return currentPersister.query("COMMIT");
-    })
-    .then(function () {
-
-        connection.done();
-
-        console.log("--------------------------------------------------".grey);
-        console.log((messages.MIGRATION_COMPLETED + currentVersion).info);
-
         process.exit(0);
     })
-    .catch(function (error) {
-
-        // Migration failed
-
-        if (error) {
-            console.error((messages.MIGRATION_ERROR + error).error);
-        }
-
-        if (connection) {
-            connection.done();
-        }
-
+    .catch(function (err) {
         process.exit(1);
     });
-
-var getMigrationService = function (persister) {
-
-    var MigratiorService = require("../lib/application/service/migrator-service");
-    var ScriptService = require("../lib/domain/service/script-service");
-    var VersionService = require("../lib/domain/service/version-service");
-    var ScriptRepository = require("../lib/domain/repository/script-repository");
-    var VersionRepository = require("../lib/domain/repository/version-repository");
-
-
-    // Service definition with dependency injection
-    return new MigratiorService(
-        new ScriptService(new ScriptRepository(fs, persister), path),
-        new VersionService(new VersionRepository(persister), messages),
-        messages);
-};

--- a/lib/application/service/migrator-service.js
+++ b/lib/application/service/migrator-service.js
@@ -1,5 +1,9 @@
 "use strict";
 
+var promise = require("bluebird");
+var _ = require("underscore");
+var colors = require("colors/safe");
+
 function MigratorService(scriptService, versionService, messages) {
     this._scriptService = scriptService;
     this._versionService = versionService;
@@ -25,7 +29,7 @@ MigratorService.prototype.migrate = function (currentPath, targetVersion) {
 
         if (fileList.length == 0) {
             // There is no migration script file in current folder and subfolders
-            console.log(messages.MIGRATION_SCRIPT_NOT_FOUND.error);
+            console.log(colors.error(messages.MIGRATION_SCRIPT_NOT_FOUND));
 
             deferred.reject();
         }
@@ -53,7 +57,7 @@ MigratorService.prototype.migrate = function (currentPath, targetVersion) {
                         // One step roll back request
                         if (currentVersion == 1) {
                             // DB in the initial state, can't go back no more
-                            console.log(messages.NO_MORE_ROLLBACK.error);
+                            console.log(colors.error(messages.NO_MORE_ROLLBACK));
 
                             return deferred.reject();
                         }
@@ -61,12 +65,12 @@ MigratorService.prototype.migrate = function (currentPath, targetVersion) {
                         targetVersion = currentVersion - 1;
                     }
 
-                    console.log((messages.CURRENT_VERSION + currentVersion).verbose);
-                    console.log((messages.TARGET_VERSION + targetVersion).verbose);
+                    console.log(colors.verbose(messages.CURRENT_VERSION + currentVersion));
+                    console.log(colors.verbose(messages.TARGET_VERSION + targetVersion));
 
                     if (currentVersion == targetVersion) {
                         // DB is already migrated to the target version
-                        console.log(messages.ALREADY_MIGRATED.warn);
+                        console.log(colors.warn(messages.ALREADY_MIGRATED));
 
                         return deferred.fulfill(currentVersion);
                     }
@@ -121,7 +125,7 @@ MigratorService.prototype._executeScript = function (direction, fileList, curren
 
         if (!file) {
             // Migration file is not found. Probably some steps missing, stop migration
-            console.log((messages.FILE_NOT_FOUND + currentVersion + "-" + nextVersion + ".sql").error);
+            console.log(colors.error(messages.FILE_NOT_FOUND + currentVersion + "-" + nextVersion + ".sql"));
 
             deferred.reject();
         }
@@ -134,13 +138,13 @@ MigratorService.prototype._executeScript = function (direction, fileList, curren
             scriptService.execute(fileContent)
                 .then(function () {
 
-                    console.log("--------------------------------------------------".grey);
+                    console.log(colors.grey("--------------------------------------------------"));
 
-                    console.log(fileContent.white);
+                    console.log(colors.white(fileContent));
 
-                    console.log((currentVersion + "-" + nextVersion + ".sql executed").info);
+                    console.log(colors.info(currentVersion + "-" + nextVersion + ".sql executed"));
 
-                    console.log("--------------------------------------------------".grey);
+                    console.log(colors.grey("--------------------------------------------------"));
 
                     // Update current version
                     currentVersion += direction;

--- a/lib/application/service/validation-service.js
+++ b/lib/application/service/validation-service.js
@@ -1,5 +1,7 @@
 "use strict";
 
+var colors = require("colors/safe");
+
 function ValidationService(messages) {
     this._messages = messages;
 }
@@ -11,7 +13,7 @@ ValidationService.prototype.validate = function (args) {
     if (args.length == 0) {
 
         // There is no argument provided but connection string argument is mandatory
-        console.log(this._messages.CONNECTION_STRING_MUST_BE_PROVIDED.error);
+        console.log(colors.error(this._messages.CONNECTION_STRING_MUST_BE_PROVIDED));
 
         return false;
     }
@@ -21,7 +23,7 @@ ValidationService.prototype.validate = function (args) {
         // Target version provided, check if valid
         if (isNaN(args[1])) {
 
-            console.log(this._messages.INVALID_TARGET_VERSION.error);
+            console.log(colors.error(this._messages.INVALID_TARGET_VERSION));
 
             return false;
         }

--- a/lib/domain/repository/version-repository.js
+++ b/lib/domain/repository/version-repository.js
@@ -1,5 +1,7 @@
 "use strict";
 
+var promise = require("bluebird");
+
 function VersionRepository(persister) {
     this._persister = persister;
 }

--- a/lib/domain/service/version-service.js
+++ b/lib/domain/service/version-service.js
@@ -1,5 +1,8 @@
 "use strict";
 
+var promise = require("bluebird");
+var colors = require("colors/safe");
+
 function VersionService(versionRepository, messages) {
     this._versionRepository = versionRepository;
     this._messages = messages;
@@ -21,7 +24,7 @@ VersionService.prototype.get = function () {
             if (!exists) {
 
                 // "version" table does not exist, will be created for the first time with version "1"
-                console.log(messages.FIRST_INITIALIZE.warn);
+                console.log(colors.warn(messages.FIRST_INITIALIZE));
 
                 versionRepository.createTable()
                     .then(function () {

--- a/migrate.js
+++ b/migrate.js
@@ -1,0 +1,87 @@
+"use strict";
+
+var fs = require("fs");
+var path = require("path");
+var colors = require("colors/safe");
+var Pgb = require("pg-bluebird");
+var messages = require("./lib/infrastructure/messages");
+
+colors.setTheme({
+    verbose: 'cyan',
+    info: 'green',
+    warn: 'yellow',
+    error: 'red'
+});
+
+function migrate (options) {
+    var connectionString = options.connectionString;
+    var targetVersion = options.targetVersion || 0;
+    var currentPath = options.path || '.';
+
+    var connection;
+    var currentPersister;
+    var currentVersion;
+
+    var persisterProvider = new Pgb();
+
+    // Connecting to PostgreSQL
+    return persisterProvider.connect(connectionString)
+        .then(function (persister) {
+
+            connection = persister;
+            currentPersister = persister.client;
+
+            // Starting transaction
+            return currentPersister.query("BEGIN TRANSACTION");
+        })
+        .then(function () {
+            return getMigrationService(currentPersister).migrate(currentPath, targetVersion);
+        })
+        .then(function (curVer) {
+
+            currentVersion = curVer;
+
+            // Migration has been completed successfully, committing the transaction
+            return currentPersister.query("COMMIT");
+        })
+        .then(function () {
+
+            connection.done();
+
+            console.log(colors.info("--------------------------------------------------"));
+            console.log(colors.info(messages.MIGRATION_COMPLETED + currentVersion));
+
+            // process.exit(0);
+        })
+        .catch(function (error) {
+            // Migration failed
+
+            if (error) {
+                console.error(colors.error(messages.MIGRATION_ERROR + error));
+            }
+
+            if (connection) {
+                connection.done();
+            }
+
+            // Rethrow error
+            throw error;
+        });
+}
+
+var getMigrationService = function (persister) {
+
+    var MigratiorService = require("./lib/application/service/migrator-service");
+    var ScriptService = require("./lib/domain/service/script-service");
+    var VersionService = require("./lib/domain/service/version-service");
+    var ScriptRepository = require("./lib/domain/repository/script-repository");
+    var VersionRepository = require("./lib/domain/repository/version-repository");
+
+    // Service definition with dependency injection
+    return new MigratiorService(
+        new ScriptService(new ScriptRepository(fs, persister), path),
+        new VersionService(new VersionRepository(persister), messages),
+        messages);
+};
+
+module.exports = migrate;


### PR DESCRIPTION
This allows library to be called directly from task runners, such as gulp, grunt or similar. Removed global references for "_" and "promise" to minimize possible side effects when importing library. Use "color/safe" version to color message to avoid modifying string prototype.